### PR TITLE
#9 Core Data 구조 단순화

### DIFF
--- a/MemoryBread/AppDelegate.swift
+++ b/MemoryBread/AppDelegate.swift
@@ -67,7 +67,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 extension AppDelegate {
     private func createInitialObjects() {
-        let context = coreDataStack.writeContext
+        let context = coreDataStack.viewContext
         
         let _ = Folder(
             context: context,
@@ -115,7 +115,7 @@ extension AppDelegate {
             )
             tutorialBread.updateFilterIndexes(usingIndexes: $0.filterIndexes)
         }
-        context.saveContextAndParentIfNeeded()
+        context.saveIfNeeded()
     }
 }
 

--- a/MemoryBread/Extensions/NSManagedObjectContext+Save.swift
+++ b/MemoryBread/Extensions/NSManagedObjectContext+Save.swift
@@ -8,31 +8,12 @@
 import CoreData
 
 extension NSManagedObjectContext {
-    func saveContextAndParentIfNeeded(forcing: Bool = false) {
-        if forcing || hasChanges {
+    func saveIfNeeded() {
+        if hasChanges {
             do {
                 try save()
-                parent?.perform {
-                    self.parent?.saveContextAndParentIfNeeded(forcing: forcing)
-                }
             } catch let nserror as NSError {
-                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
-            }
-        }
-    }
-    
-    func saveContextAndParentIfNeededThrows() throws {
-        if hasChanges {
-            try save()
-            
-            if parent?.hasChanges ?? false {
-                parent?.perform {
-                    do {
-                        try self.parent?.save()
-                    } catch let nserror as NSError {
-                        fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
-                    }
-                }
+                fatalError("CoreDataStack save failed: \(nserror), \(nserror.userInfo)")
             }
         }
     }

--- a/MemoryBread/Models/FolderModel/FolderModel.swift
+++ b/MemoryBread/Models/FolderModel/FolderModel.swift
@@ -62,7 +62,7 @@ final class FolderModel {
             }
             
             moc.perform {
-                self.moc.saveContextAndParentIfNeeded()
+                self.moc.saveIfNeeded()
             }
         }
     }

--- a/MemoryBread/Models/FolderModel/FolderModel.swift
+++ b/MemoryBread/Models/FolderModel/FolderModel.swift
@@ -32,9 +32,10 @@ final class FolderModel {
             )
             
             do {
-                try saveContextAndItsParentIfNeeded()
+                try moc.save()
                 result = newFolder.objectID
             } catch let nserror as NSError{
+                moc.rollback()
                 switch nserror.code {
                 case NSManagedObjectConstraintMergeError:
                     saveError = ContextSaveError.folderNameIsDuplicated
@@ -86,8 +87,9 @@ final class FolderModel {
             
             folder.setName(newFolderName)
             do {
-                try saveContextAndItsParentIfNeeded()
+                try moc.save()
             } catch let nserror as NSError {
+                moc.rollback()
                 switch nserror.code {
                 case NSManagedObjectConstraintMergeError:
                     saveError = ContextSaveError.folderNameIsDuplicated
@@ -116,24 +118,7 @@ final class FolderModel {
             }
             
             moc.delete(folder)
-            do {
-                try self.saveContextAndItsParentIfNeeded()
-            } catch {
-                fatalError("Saving for deleting folder is failed.")
-            }
-        }
-    }
-    
-    private func saveContextAndItsParentIfNeeded() throws {
-        if moc.hasChanges {
-            do {
-                try moc.save()
-                try moc.parent?.save()
-            } catch {
-                moc.parent?.rollback()
-                moc.rollback()
-                throw error
-            }
+            moc.saveIfNeeded()
         }
     }
     

--- a/MemoryBread/Models/FolderModel/FolderModel.swift
+++ b/MemoryBread/Models/FolderModel/FolderModel.swift
@@ -9,12 +9,13 @@ import Foundation
 import CoreData
 
 final class FolderModel {
-    private let moc: NSManagedObjectContext
     private var foldersIndexChangedFlag = false
-    var trashObjectID: NSManagedObjectID?
+
+    private let coreDataStack: CoreDataStack
+    var container: NSPersistentContainer { coreDataStack.persistentContainer }
     
-    init(context: NSManagedObjectContext) {
-        self.moc = context
+    init(coreDataStack: CoreDataStack) {
+        self.coreDataStack = coreDataStack
     }
    
     @discardableResult
@@ -23,19 +24,20 @@ final class FolderModel {
         
         var result: NSManagedObjectID?
         var saveError: ContextSaveError? = nil
-        moc.performAndWait {
+        let writeContext = container.newBackgroundContext()
+        writeContext.performAndWait {
             let newFolder = Folder(
-                context: moc,
+                context: writeContext,
                 name: name,
                 index: index,
                 breads: nil
             )
             
             do {
-                try moc.save()
+                try writeContext.save()
                 result = newFolder.objectID
             } catch let nserror as NSError{
-                moc.rollback()
+                writeContext.rollback()
                 switch nserror.code {
                 case NSManagedObjectConstraintMergeError:
                     saveError = ContextSaveError.folderNameIsDuplicated
@@ -52,18 +54,19 @@ final class FolderModel {
     }
     
     func updateFoldersIndexIfNeeded(of folderObjectIDs: [NSManagedObjectID]) {
-        moc.performAndWait {
+        let viewContext = container.viewContext
+        viewContext.performAndWait {
             folderObjectIDs.enumerated().forEach { index, objectID in
                 let newIndex = Int64(index)
-                if let folderObject = try? moc.existingObject(with: objectID) as? Folder,
+                if let folderObject = try? viewContext.existingObject(with: objectID) as? Folder,
                    folderObject.index != newIndex {
                     folderObject.index = newIndex
                     foldersIndexChangedFlag = true
                 }
             }
             
-            moc.perform {
-                self.moc.saveIfNeeded()
+            viewContext.perform {
+                viewContext.saveIfNeeded()
             }
         }
     }
@@ -80,16 +83,17 @@ final class FolderModel {
         try isInBlackList(newFolderName)
         
         var saveError: ContextSaveError?
-        moc.performAndWait {
-            guard let folder = moc.object(with: folderObjectID) as? Folder else {
+        let writeContext = container.newBackgroundContext()
+        writeContext.performAndWait {
+            guard let folder = writeContext.object(with: folderObjectID) as? Folder else {
                 fatalError("Folder casting fail")
             }
             
             folder.setName(newFolderName)
             do {
-                try moc.save()
+                try writeContext.save()
             } catch let nserror as NSError {
-                moc.rollback()
+                writeContext.rollback()
                 switch nserror.code {
                 case NSManagedObjectConstraintMergeError:
                     saveError = ContextSaveError.folderNameIsDuplicated
@@ -105,11 +109,12 @@ final class FolderModel {
     }
     
     func delete(_ folderObjectID: NSManagedObjectID) {
-        moc.perform { [moc, trashObjectID] in
-            guard let folder = try? moc.existingObject(with: folderObjectID) as? Folder,
+        let trashObjectID = coreDataStack.trashFolderObjectID
+        let writeContext = container.newBackgroundContext()
+        writeContext.perform {
+            guard let folder = try? writeContext.existingObject(with: folderObjectID) as? Folder,
                   let allBreadsInFolder = folder.breads?.allObjects as? [Bread],
-                  let trashObjectID = trashObjectID,
-                  let trash = try? moc.existingObject(with: trashObjectID) as? Folder else {
+                  let trash = try? writeContext.existingObject(with: trashObjectID) as? Folder else {
                       return
                   }
             
@@ -117,8 +122,8 @@ final class FolderModel {
                 $0.move(to: trash)
             }
             
-            moc.delete(folder)
-            moc.saveIfNeeded()
+            writeContext.delete(folder)
+            writeContext.saveIfNeeded()
         }
     }
     

--- a/MemoryBread/Models/MoveBread/MoveBreadModel.swift
+++ b/MemoryBread/Models/MoveBread/MoveBreadModel.swift
@@ -101,7 +101,7 @@ extension MoveBreadModel {
             }
         
             self.moveSelectedBreads(to: destFolder)
-            self.moc.saveContextAndParentIfNeeded()
+            self.moc.saveIfNeeded()
         }
     }
 

--- a/MemoryBread/Protocols/MoveBreadViewControllerPresentable.swift
+++ b/MemoryBread/Protocols/MoveBreadViewControllerPresentable.swift
@@ -10,15 +10,13 @@ import CoreData
 
 protocol MoveBreadViewControllerPresentable where Self: UIViewController {
     var sourceFolderObjectID: NSManagedObjectID? { get }
-    var trashFolderObjectID: NSManagedObjectID { get }
-    
-    func presentMoveBreadViewControllerWith(context: NSManagedObjectContext, targetBreadObjectIDs: [NSManagedObjectID])
+    func presentMoveBreadViewControllerWith(coreDataStack: CoreDataStack, targetBreadObjectIDs: [NSManagedObjectID])
 }
 
 extension MoveBreadViewControllerPresentable {
-    func presentMoveBreadViewControllerWith(context: NSManagedObjectContext, targetBreadObjectIDs: [NSManagedObjectID]) {
+    func presentMoveBreadViewControllerWith(coreDataStack: CoreDataStack, targetBreadObjectIDs: [NSManagedObjectID]) {
         let model = MoveBreadModel(
-            context: context,
+            coreDataStack: coreDataStack,
             selectedBreadObjectIDs: targetBreadObjectIDs,
             shouldDisabledFolderObjectID: sourceFolderObjectID
         )

--- a/MemoryBread/SceneDelegate.swift
+++ b/MemoryBread/SceneDelegate.swift
@@ -27,7 +27,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     func sceneWillResignActive(_ scene: UIScene) {
-        let context = AppDelegate.coreDataStack.writeContext
+        let context = AppDelegate.coreDataStack.viewContext
         context.perform {
             do {
                 try context.save()

--- a/MemoryBread/ViewControllers/BreadListViewController.swift
+++ b/MemoryBread/ViewControllers/BreadListViewController.swift
@@ -342,7 +342,7 @@ extension BreadListViewController: BreadListViewDelegate {
         
         let selectedObjectIDs = breads(at: rows).map { $0.objectID }
         presentMoveBreadViewControllerWith(
-            context: coreDataStack.persistentContainer.newBackgroundContext(),
+            coreDataStack: coreDataStack,
             targetBreadObjectIDs: selectedObjectIDs
         )
     }
@@ -350,7 +350,7 @@ extension BreadListViewController: BreadListViewDelegate {
     func moveAllButtonTouched() {
         let allObjectIDs = diffableDataSource.snapshot().itemIdentifiers
         presentMoveBreadViewControllerWith(
-            context: coreDataStack.persistentContainer.newBackgroundContext(),
+            coreDataStack: coreDataStack,
             targetBreadObjectIDs: allObjectIDs
         )
     }
@@ -469,10 +469,6 @@ extension BreadListViewController: NSFetchedResultsControllerDelegate {
 extension BreadListViewController: MoveBreadViewControllerPresentable {
     var sourceFolderObjectID: NSManagedObjectID? {
         isAllBreadsFolder ? nil : currentFolderObjectID
-    }
-    
-    var trashFolderObjectID: NSManagedObjectID {
-        trashObjectID
     }
 }
 

--- a/MemoryBread/ViewControllers/BreadViewController.swift
+++ b/MemoryBread/ViewControllers/BreadViewController.swift
@@ -96,7 +96,7 @@ final class BreadViewController: UIViewController {
         let latestSelectedFilters = bread.selectedFilters
         if latestSelectedFilters != selectedFiltersArray {
             bread.selectedFilters = Array(selectedFilters)
-            viewContext.saveContextAndParentIfNeeded()
+            viewContext.saveIfNeeded()
         }
     }
     
@@ -112,7 +112,7 @@ final class BreadViewController: UIViewController {
         }
         
         wordPainter.makeFilterIndexesUpToDate()
-        viewContext.saveContextAndParentIfNeeded()
+        viewContext.saveIfNeeded()
 
         dataSource.reconfigure(wordPainter.idsHavingFilter(), animatingDifferences: true)
         editContentButtonItem.isEnabled = true
@@ -462,7 +462,7 @@ extension BreadViewController: SupplemantaryTitleViewDelegate {
             NotificationCenter.default.removeObserver(self, name: UITextField.textDidChangeNotification, object: titleEditAlert?.textFields?.first)
             if let inputText = titleEditAlert?.textFields?.first?.text?.trimmingCharacters(in: [" "]) {
                 self.bread.updateTitle(inputText)
-                self.viewContext.saveContextAndParentIfNeeded()
+                self.viewContext.saveIfNeeded()
                 self.updateNaviTitleView(using: inputText)
             }
         }
@@ -499,7 +499,7 @@ extension BreadViewController {
         guard bread.content != newContent else { return }
 
         bread.updateContent(with: newContent)
-        viewContext.saveContextAndParentIfNeeded()
+        viewContext.saveIfNeeded()
         
         wordPainter.refreshItems()
         

--- a/MemoryBread/ViewControllers/DriveFileListViewController.swift
+++ b/MemoryBread/ViewControllers/DriveFileListViewController.swift
@@ -341,7 +341,7 @@ extension DriveFileListViewController: FileListCellDelegate {
                                     )
                                 }
 
-                                self.writeContext.saveContextAndParentIfNeeded()
+                                self.writeContext.saveIfNeeded()
                                 
                                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                                     loadingVC.set(state: .init(isLoading: false))

--- a/MemoryBread/ViewControllers/FoldersViewController.swift
+++ b/MemoryBread/ViewControllers/FoldersViewController.swift
@@ -68,10 +68,8 @@ final class FoldersViewController: UIViewController {
     
     init(coreDataStack: CoreDataStack) {
         self.coreDataStack = coreDataStack
-        self.folderModel = FolderModel(context: coreDataStack.persistentContainer.newBackgroundContext())
+        self.folderModel = FolderModel(coreDataStack: coreDataStack)
         super.init(nibName: nil, bundle: nil)
-        
-        self.folderModel.trashObjectID = coreDataStack.trashFolderObjectID
     }
     
     override func viewDidLoad() {

--- a/MemoryBread/ViewControllers/FoldersViewController.swift
+++ b/MemoryBread/ViewControllers/FoldersViewController.swift
@@ -68,7 +68,7 @@ final class FoldersViewController: UIViewController {
     
     init(coreDataStack: CoreDataStack) {
         self.coreDataStack = coreDataStack
-        self.folderModel = FolderModel(context: coreDataStack.writeContext)
+        self.folderModel = FolderModel(context: coreDataStack.persistentContainer.newBackgroundContext())
         super.init(nibName: nil, bundle: nil)
         
         self.folderModel.trashObjectID = coreDataStack.trashFolderObjectID
@@ -474,7 +474,7 @@ extension FoldersViewController: NSFetchedResultsControllerDelegate {
     private func fetchAllBreadsCount() -> Int {
         let fr = Bread.fetchRequest()
         fr.predicate = NSPredicate(format: "folder.pinnedAtBottom = NO")
-        let breadsCount = (try? coreDataStack.writeContext.count(for: fr)) ?? 0
+        let breadsCount = (try? viewContext.count(for: fr)) ?? 0
         return breadsCount
     }
     

--- a/MemoryBread/ViewControllers/TrashViewController.swift
+++ b/MemoryBread/ViewControllers/TrashViewController.swift
@@ -265,7 +265,7 @@ extension TrashViewController: BreadListViewDelegate {
         
         let selectedObjectIDs = breads(at: rows).map { $0.objectID }
         presentMoveBreadViewControllerWith(
-            context: coreDataStack.persistentContainer.newBackgroundContext(),
+            coreDataStack: coreDataStack,
             targetBreadObjectIDs: selectedObjectIDs
         )
     }
@@ -273,7 +273,7 @@ extension TrashViewController: BreadListViewDelegate {
     func moveAllButtonTouched() {
         let allObjectIDs = dataSource.snapshot().itemIdentifiers
         presentMoveBreadViewControllerWith(
-            context: coreDataStack.persistentContainer.newBackgroundContext(),
+            coreDataStack: coreDataStack,
             targetBreadObjectIDs: allObjectIDs
         )
     }
@@ -393,10 +393,6 @@ extension TrashViewController: NSFetchedResultsControllerDelegate {
 // MARK: - MoveBreadViewControllerPresentable
 extension TrashViewController: MoveBreadViewControllerPresentable {
     var sourceFolderObjectID: NSManagedObjectID? {
-        trashObjectID
-    }
-    
-    var trashFolderObjectID: NSManagedObjectID {
         trashObjectID
     }
 }


### PR DESCRIPTION
`NSDiffableDataSource` 와 `NSFetchedResultControllerDelegate.controller(_:didChangeContentWith:)`를  
사용하기 위해서 [특정 문제](https://sweethoneybee.tistory.com/60)를 해결하기 위해 복잡한 `NSManagedObjectContext`구조를 구현했었음.   

앱의 규모와 기능을 고려했을 때, 아직 불필요한 구조였고 제대로 구현해내지 못하고 있었기에 구조를 단순화하는 작업을 수행함.
(기존 `psc <- WriteContext <- ViewContext` 에서 `psc <- ViewContext` 로 단순화)